### PR TITLE
Fix the getting a project instance according to active solution configuration

### DIFF
--- a/vsSolutionBuildEvent/EnvAbstract.cs
+++ b/vsSolutionBuildEvent/EnvAbstract.cs
@@ -41,6 +41,8 @@ namespace net.r_eg.vsSBE
         /// </summary>
         public abstract string SolutionFile { get; protected set; }
 
+        protected abstract ConfigItem ActiveSlnConf { get; }
+
         protected abstract void UpdateSlnEnv(ISlnResult sln);
 
         /// <summary>
@@ -108,16 +110,19 @@ namespace net.r_eg.vsSBE
 
             Log.Trace($"getProject: started with '{name}' /{StartupProjectString}");
 
-            if(String.IsNullOrEmpty(name)) {
-                name = StartupProjectString;
-            }
+            if(string.IsNullOrEmpty(name)) name = StartupProjectString;
 
             ProjectItem project = Sln.ProjectItems.FirstOrDefault(p => p.name == name);
             if(project.fullPath == null) {
                 throw new NotFoundException($"Project '{name}' was not found. ['{project.name}', '{project.pGuid}']");
             }
 
-            return SlnEnv?.GetOrLoadProject(project);
+            IConfPlatformPrj cfg = Sln.ProjectItemsConfigs
+                                        .FirstOrDefault(p => ActiveSlnConf?.Equals(p.solutionConfig) == true)
+                                        .projectConfig;
+
+            return (cfg == null) ? SlnEnv?.GetOrLoadProject(project) 
+                                 : SlnEnv?.GetOrLoadProject(project, cfg);
         }
 
         /// <summary>

--- a/vsSolutionBuildEvent/Environment.cs
+++ b/vsSolutionBuildEvent/Environment.cs
@@ -51,13 +51,12 @@ namespace net.r_eg.vsSBE
 
         private string startupProject;
 
+        private ConfigItem currentSlnConf;
+
         /// <summary>
         /// List of EnvDTE projects.
         /// </summary>
-        public IEnumerable<DProject> ProjectsDTE
-        {
-            get => _DTEProjects;
-        }
+        public IEnumerable<DProject> ProjectsDTE => _DTEProjects;
 
         /// <summary>
         /// List of Microsoft.Build.Evaluation projects.
@@ -280,6 +279,23 @@ namespace net.r_eg.vsSBE
                         yield return subproject;
                     }
                 }
+            }
+        }
+
+        protected override ConfigItem ActiveSlnConf
+        {
+            get
+            {
+                SolutionConfiguration2 cfg = SolutionActiveCfg;
+                if(cfg == null) return null;
+
+                if(currentSlnConf?.IsEqualByRule(cfg.Name, cfg.PlatformName) == true)
+                {
+                    return currentSlnConf;
+                }
+
+                currentSlnConf = new(cfg.Name, cfg.PlatformName);
+                return currentSlnConf;
             }
         }
 

--- a/vsSolutionBuildEvent/IsolatedEnv.cs
+++ b/vsSolutionBuildEvent/IsolatedEnv.cs
@@ -41,6 +41,8 @@ namespace net.r_eg.vsSBE
 
         protected readonly IConfPlatform defaultCfg = new ConfigSln("Debug", "Any CPU");
 
+        private ConfigItem currentSlnConf;
+
         private string _startupProjectString;
 
         private readonly IDictionary<string, string> _properties;
@@ -178,6 +180,8 @@ namespace net.r_eg.vsSBE
             get => __disabled<IOW>(nameof(OutputWindowPane));
         }
 
+        protected override ConfigItem ActiveSlnConf => extractCfg(slnProperties);
+
         /// <summary>
         /// An unified unscoped and out of Project instance the property value by its name.
         /// Remarks: Any property values cannot be null.
@@ -292,14 +296,20 @@ namespace net.r_eg.vsSBE
             return properties;
         }
 
-        protected IConfPlatform extractCfg(IDictionary<string, string> properties)
+        protected ConfigItem extractCfg(IDictionary<string, string> properties)
         {
             IConfPlatform def = Sln?.DefaultConfig;
 
-            return new ConfigItem(
-                properties.GetOrDefault(PropertyNames.CONFIG, def?.Configuration),
-                properties.GetOrDefault(PropertyNames.PLATFORM, def?.Platform)
-            );
+            string configuration = properties.GetOrDefault(PropertyNames.CONFIG, def?.Configuration);
+            string platform = properties.GetOrDefault(PropertyNames.PLATFORM, def?.Platform);
+
+            if(currentSlnConf?.IsEqualByRule(configuration, platform) == true)
+            {
+                return currentSlnConf;
+            }
+
+            currentSlnConf = new(configuration, platform);
+            return currentSlnConf;
         }
 
         protected string formatCfg(IDictionary<string, string> properties)


### PR DESCRIPTION
Fixes #71

It's not yet completed due to another bug in [MvsSln](https://github.com/3F/MvsSln) handling that activates the wrong instance in its collection.